### PR TITLE
ci: allow workflow to push with token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure release workflow can push using `GITHUB_TOKEN`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c101679e48332bd41598e030a4fd3