### PR TITLE
refactor: rename package to proxy.sh and CLI to proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# api-gateway
+# proxy.sh
 
 Proxy server that emulates a simple AWS API Gateway locally. The published
 package already includes the compiled JavaScript so it can be executed directly
@@ -9,14 +9,14 @@ with **npx** or after installing globally.
 Use `npx` to run the latest released version without installing:
 
 ```bash
-npx api-gateway start --help
+npx proxy.sh start --help
 ```
 
-Or install globally and use the `agw` command:
+Or install globally and use the `proxy` command:
 
 ```bash
-npm install -g api-gateway
-agw start --help
+npm install -g proxy.sh
+proxy start --help
 ```
 
 ## Usage
@@ -24,7 +24,7 @@ agw start --help
 Run with inline configuration:
 
 ```bash
-npx api-gateway start -p 8000 \
+npx proxy.sh start -p 8000 \
   --node auth --destiny http://localhost:9000 \
   --node products --destiny http://localhost:9001
 ```
@@ -33,31 +33,31 @@ If you omit options the CLI will prompt for them using **inquirer**.
 
 ### Config files
 
-Save a configuration to `~/.agw/myconfig.json` using `--save`:
+Save a configuration to `~/.proxy/myconfig.json` using `--save`:
 
 ```bash
-npx api-gateway start --save myconfig
+npx proxy.sh start --save myconfig
 ```
 
 Run the gateway using that configuration:
 
 ```bash
-npx api-gateway start --config myconfig
+npx proxy.sh start --config myconfig
 ```
 
 ### Background mode
 
 Start the gateway in the background and log each service to
-`~/.agw/logs/[node].log`:
+`~/.proxy/logs/[node].log`:
 
 ```bash
-npx api-gateway start --config myconfig --daemon
+npx proxy.sh start --config myconfig --daemon
 ```
 
 View a service log:
 
 ```bash
-npx api-gateway logs auth
+npx proxy.sh logs auth
 ```
 
 ## Options (start command)
@@ -72,7 +72,7 @@ npx api-gateway logs auth
 For viewing logs use:
 
 ```bash
-npx api-gateway logs <node>
+npx proxy.sh logs <node>
 ```
 
 ## License

--- a/dist/cli/commands/start.js
+++ b/dist/cli/commands/start.js
@@ -22,10 +22,10 @@ function makeStartCommand() {
         .option('--log', 'Enable request logging')
         .option('--daemon', 'Run in background')
         .addHelpText('after', `\nExamples:\n` +
-        `  $ npx agw start -p 8000 --node auth --destiny http://localhost:9000\n` +
-        `  $ npx agw start --save myconfig\n` +
-        `  $ npx agw start --config myconfig\n` +
-        `  $ npx agw start --daemon --config myconfig\n`);
+        `  $ npx proxy start -p 8000 --node auth --destiny http://localhost:9000\n` +
+        `  $ npx proxy start --save myconfig\n` +
+        `  $ npx proxy start --config myconfig\n` +
+        `  $ npx proxy start --daemon --config myconfig\n`);
     cmd.action(async (opts) => {
         if (opts.daemon) {
             const args = process.argv.slice(3).filter(a => a !== '--daemon');

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -6,7 +6,7 @@ const start_1 = require("./commands/start");
 const logs_1 = require("./commands/logs");
 const program = new commander_1.Command();
 program
-    .name('agw')
+    .name('proxy')
     .description('Local API Gateway proxy');
 program.addCommand((0, start_1.makeStartCommand)());
 program.addCommand((0, logs_1.makeLogsCommand)());

--- a/dist/domain/config.js
+++ b/dist/domain/config.js
@@ -13,7 +13,7 @@ const os_1 = __importDefault(require("os"));
 function resolveConfigPath(name) {
     if (path_1.default.isAbsolute(name))
         return name;
-    const base = path_1.default.join(os_1.default.homedir(), '.agw');
+    const base = path_1.default.join(os_1.default.homedir(), '.proxy');
     if (!name.endsWith('.json'))
         name += '.json';
     return path_1.default.join(base, name);
@@ -35,7 +35,7 @@ function saveConfig(name, cfg) {
     console.log(green(`Configuration saved to ${file}`));
 }
 function ensureLogsDir() {
-    const dir = path_1.default.join(os_1.default.homedir(), '.agw', 'logs');
+    const dir = path_1.default.join(os_1.default.homedir(), '.proxy', 'logs');
     if (!fs_1.default.existsSync(dir))
         fs_1.default.mkdirSync(dir, { recursive: true });
     return dir;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "api-gateway",
+  "name": "proxy.sh",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "api-gateway",
+      "name": "proxy.sh",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -16,7 +16,7 @@
         "inquirer": "^9.2.7"
       },
       "bin": {
-        "agw": "dist/cli/index.js"
+        "proxy": "dist/cli/index.js"
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "api-gateway",
+  "name": "proxy.sh",
   "version": "1.0.0",
   "description": "Local API Gateway proxy",
   "main": "dist/cli/index.js",
@@ -12,7 +12,7 @@
   "license": "ISC",
   "type": "commonjs",
   "bin": {
-    "agw": "dist/cli/index.js"
+    "proxy": "dist/cli/index.js"
   },
   "files": [
     "dist"

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -17,10 +17,10 @@ export function makeStartCommand(): Command {
     .option('--log', 'Enable request logging')
     .option('--daemon', 'Run in background')
     .addHelpText('after', `\nExamples:\n` +
-      `  $ npx agw start -p 8000 --node auth --destiny http://localhost:9000\n` +
-      `  $ npx agw start --save myconfig\n` +
-      `  $ npx agw start --config myconfig\n` +
-      `  $ npx agw start --daemon --config myconfig\n`);
+      `  $ npx proxy start -p 8000 --node auth --destiny http://localhost:9000\n` +
+      `  $ npx proxy start --save myconfig\n` +
+      `  $ npx proxy start --config myconfig\n` +
+      `  $ npx proxy start --daemon --config myconfig\n`);
 
   cmd.action(async (opts) => {
     if (opts.daemon) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,7 +5,7 @@ import { makeLogsCommand } from './commands/logs';
 
 const program = new Command();
 program
-  .name('agw')
+  .name('proxy')
   .description('Local API Gateway proxy');
 
 program.addCommand(makeStartCommand());

--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -11,7 +11,7 @@ export interface Config {
 
 export function resolveConfigPath(name: string): string {
   if (path.isAbsolute(name)) return name;
-  const base = path.join(os.homedir(), '.agw');
+  const base = path.join(os.homedir(), '.proxy');
   if (!name.endsWith('.json')) name += '.json';
   return path.join(base, name);
 }
@@ -33,7 +33,7 @@ export function saveConfig(name: string, cfg: Config) {
 }
 
 export function ensureLogsDir() {
-  const dir = path.join(os.homedir(), '.agw', 'logs');
+  const dir = path.join(os.homedir(), '.proxy', 'logs');
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   return dir;
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -10,6 +10,6 @@ describe('resolveConfigPath', () => {
 
   it('resolves names in home directory', () => {
     const result = resolveConfigPath('foo');
-    expect(result).toBe(path.join(os.homedir(), '.agw', 'foo.json'));
+    expect(result).toBe(path.join(os.homedir(), '.proxy', 'foo.json'));
   });
 });


### PR DESCRIPTION
## Summary
- rename package to `proxy.sh` and CLI binary to `proxy`
- update config and docs to use `~/.proxy` paths and new command names

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c4307829883329b4f4561eb7e5509