### PR TITLE
fix: ensure npm token available for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,4 +63,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary
- expose npm token to semantic-release action by also setting `NODE_AUTH_TOKEN`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c4604fe948332bb158919738b6d0d