### PR TITLE
fix: silence util extend deprecation and handle proxy errors

### DIFF
--- a/src/application/server.ts
+++ b/src/application/server.ts
@@ -1,12 +1,32 @@
 import express from 'express';
 import chalk from 'chalk';
-import { createProxyMiddleware } from 'http-proxy-middleware';
+import util from 'util';
+import { IncomingMessage } from 'http';
 import { Config } from '../domain/config';
 import { logToFile } from '../domain/logs';
 
+function logger(context: string, message: string, color: (s: string) => string = chalk.white) {
+  const pid = process.pid;
+  const timestamp = new Date().toISOString();
+  const level = chalk.green('LOG');
+  const ctx = color(`[${context}]`);
+  console.log(`[Nest] ${pid}   - ${timestamp}   ${level} ${ctx} ${message}`);
+}
+
 export async function startServer(cfg: Config) {
+  // Avoid Node deprecation warning by replacing the deprecated util._extend
+  // used by the http-proxy dependency with Object.assign before requiring it.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((util as any)._extend) {
+    (util as any)._extend = Object.assign;
+  }
+
+  // Load http-proxy-middleware after patching util._extend.
+  const { createProxyMiddleware } = await import('http-proxy-middleware');
+
   const app = express();
   const colors = [chalk.cyan, chalk.magenta, chalk.yellow, chalk.green];
+  const requestTimings = new WeakMap<IncomingMessage, number>();
 
   cfg.nodes.forEach((node, idx) => {
     const dest = cfg.destinies[idx];
@@ -19,8 +39,28 @@ export async function startServer(cfg: Config) {
       pathRewrite: (p) => p.replace(new RegExp('^' + prefix), ''),
       onProxyReq: (_, req) => {
         const msg = `${req.method} ${req.originalUrl} -> ${dest}`;
-        if (cfg.log) console.log(color(msg));
+        if (cfg.log) logger('Request', msg, color);
         logToFile(node, `${new Date().toISOString()} ${msg}`);
+        requestTimings.set(req, Date.now());
+      },
+      onProxyRes: (proxyRes, req) => {
+        const start = requestTimings.get(req) || Date.now();
+        requestTimings.delete(req);
+        const ms = Date.now() - start;
+        const msg = `${req.method} ${req.originalUrl} ${proxyRes.statusCode} +${ms}ms`;
+        if (cfg.log) logger('Response', msg, color);
+        logToFile(node, `${new Date().toISOString()} ${msg}`);
+      },
+      onError: (err, req, res) => {
+        const start = requestTimings.get(req) || Date.now();
+        requestTimings.delete(req);
+        const ms = Date.now() - start;
+        const msg = `${req.method} ${req.originalUrl} 502 +${ms}ms`;
+        if (cfg.log) logger('Response', msg, color);
+        logToFile(node, `${new Date().toISOString()} ${msg}`);
+        console.error('Proxy error:', err.message);
+        res.writeHead(502, { 'Content-Type': 'text/plain' });
+        res.end('Bad gateway\n');
       }
     }));
   });


### PR DESCRIPTION
## Summary
- avoid Node util._extend deprecation by patching only when the property exists
- log proxy failures and respond with a clear 502 message when upstream services are unreachable
- print request and response details in a NestJS-style format via a generic logger and track timings with a WeakMap

## Testing
- `npm run build`
- `npm test`
- `npx proxy start -p 3000 --node auth --destiny http://localhost:9001/auth --node payments --destiny http://localhost:9001/payments --log --save test`
- `curl -i http://localhost:3000/auth/me`


------
https://chatgpt.com/codex/tasks/task_e_688c527fc6d08332870adae1cc5d0e44